### PR TITLE
Add support for RHEL 8

### DIFF
--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -36,6 +36,7 @@ class postfix::defaults {
       $dist_version = $facts['os']['release']['major'] ? {
         '6' => '2.6.6',
         '7' => '2.10.1',
+        '8' => '3.3.1',
       }
       $chroot = false
     }


### PR DESCRIPTION
Module fails on RHEL 8:
Error while evaluating a Resource Statement, Evaluation Error: No matching entry for selector                                                              parameter with value '8' (file: postfix/manifests/defaults.pp, line: 36, column: 23)